### PR TITLE
Add option to choose conversion on model's view page

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Laravel Advanced Nova Media Library
 
-Manage images of [spatie's media library package](https://github.com/spatie/laravel-medialibrary). Upload multiple 
+Manage images of [spatie's media library package](https://github.com/spatie/laravel-medialibrary). Upload multiple
 images and order them by drag and drop.
 
 ## Install
@@ -38,13 +38,13 @@ use Ebess\AdvancedNovaMediaLibrary\Fields\Images;
 public function fields(Request $request)
 {
     return [
-        Images::make('Main image', 'main') // second parameter is the media collection name 
+        Images::make('Main image', 'main') // second parameter is the media collection name
             ->thumbnail('thumb') // conversion used to display the image
             ->rules('required'), // validation rules
     ];
 }
 ```
- 
+
 ## Multiple image upload
 
 If you enable the multiple upload ability, you can **order the images via drag & drop**.
@@ -59,7 +59,8 @@ use Ebess\AdvancedNovaMediaLibrary\Fields\Images;
         return [
             Images::make('Images', 'my_multi_collection') // second parameter is the media collection name
                 ->conversion('medium-size') // conversion used to display the "original" image
-                ->thumbnail('thumb') // conversion used to display the image
+                ->conversionOnView('thumb') // conversion used on the model's view
+                ->thumbnail('thumb') // conversion used to display the image on the model's index page
                 ->multiple() // enable upload of multiple images - also ordering
                 ->fullSize() // full size column
                 ->rules('required', 'size:3') // validation rules for the collection of images
@@ -79,7 +80,7 @@ Images::make('Image 1', 'img1')
     ->setFileName(function($originalFilename, $extension, $model){
         return md5($originalFilename) . '.' . $extension;
     });
-    
+
 // Set the filename to the model name
 Images::make('Image 2', 'img2')
     ->setFileName(function($originalFilename, $extension, $model){

--- a/resources/js/components/SingleImage.vue
+++ b/resources/js/components/SingleImage.vue
@@ -17,6 +17,11 @@
     props: ['image', 'thumbnail', 'removable'],
     computed: {
       src() {
+        // Return desired image conversion on view if it exists
+        if (this.image.id && this.conversionOnView && this.image.full_urls[this.conversionOnView]) {
+          return this.image.full_urls[this.conversionOnView];
+        }
+        // Return thumnail if conversion exists
         if (this.image.id && this.thumbnail && this.image.full_urls[this.thumbnail]) {
           return this.image.full_urls[this.thumbnail];
         }

--- a/src/Fields/Images.php
+++ b/src/Fields/Images.php
@@ -12,7 +12,7 @@ use Illuminate\Support\Facades\Validator;
 class Images extends Field
 {
     public $component = 'advanced-media-library-field';
-    
+
     protected $setFileNameCallback;
 
     protected $setNameCallback;
@@ -27,6 +27,11 @@ class Images extends Field
     public function conversion(string $conversion): self
     {
         return $this->withMeta(compact('conversion'));
+    }
+
+    public function conversionOnView(string $conversionOnView): self
+    {
+        return $this->withMeta(compact('conversionOnView'));
     }
 
     public function multiple(): self
@@ -91,7 +96,7 @@ class Images extends Field
                 return $value instanceof UploadedFile;
             })->map(function (UploadedFile $file) use ($model, $collection) {
                 $media = $model->addMedia($file);
-                
+
                 if(is_callable($this->setFileNameCallback)) {
                     $media->setFileName(
                         call_user_func($this->setFileNameCallback, $file->getClientOriginalName(), $file->getClientOriginalExtension(), $model)
@@ -103,7 +108,7 @@ class Images extends Field
                         call_user_func($this->setNameCallback, $file->getClientOriginalName(), $model)
                     );
                 }
-                
+
                 return $media
                     ->toMediaCollection($collection)
                     ->getKey();
@@ -145,6 +150,10 @@ class Images extends Field
                     $urls[$thumbnail] = $media->getFullUrl($thumbnail);
                 }
 
+                if ($conversionOnView = $this->meta['conversionOnView'] ?? null) {
+                    $urls[$conversionOnView] = $media->getFullUrl($conversionOnView);
+                }
+
                 return array_merge($media->toArray(), ['full_urls' => $urls]);
             });
 
@@ -153,17 +162,17 @@ class Images extends Field
             $this->withMeta(compact('thumbnailUrl'));
         }
     }
-    
+
     /**
      * Set a filename callable callback
-     * 
+     *
      * @param callable $callback
      *
      * @return $this
      */
     public function setFileName($callback) {
         $this->setFileNameCallback = $callback;
-        
+
         return $this;
     }
 


### PR DESCRIPTION
Some projects have rather large images which would result in bad load-times on the model's view page where all original images would be loaded.
Before it tried to find a conversion with the exact name 'thumbnail' and would return the original if it was not found. This implementations provides the option to choose the conversion to use in case the conversion you'd like to use is not called 'thumbnail'.