### PR TITLE
custom header #98

### DIFF
--- a/src/Fields/Media.php
+++ b/src/Fields/Media.php
@@ -24,6 +24,8 @@ class Media extends Field
 
     protected $collectionMediaRules = [];
     protected $singleMediaRules = [];
+	
+    protected $customHeaders = [];
 
     protected $defaultValidatorRules = [];
 
@@ -53,6 +55,13 @@ class Media extends Field
         $this->singleMediaRules = ($rules instanceof Rule || is_string($rules)) ? func_get_args() : $rules;
 
         return $this;
+    }
+	
+    public function customHeaders(array $headers): self
+    {
+	$this->customHeaders = $headers;
+	
+	return $this;
     }
 
     /**
@@ -150,6 +159,10 @@ class Media extends Field
                 if($this->responsive) {
                     $media->withResponsiveImages();
                 }
+		
+		if(!empty($this->customHeaders)) {
+		    $media->addCustomHeaders($this->customHeaders);
+		}
 
                 if (is_callable($this->setFileNameCallback)) {
                     $media->setFileName(


### PR DESCRIPTION
this fixes issue #98. now can pass custom header when creating media.  
for example to set file as public in s3 compatible storage pass custom header like this

```
Files::make('Multiple files', 'multiple_files')
    ->customHeaders([
        'ACL' => 'public-read'
    ]);
```