### PR TITLE
Use injected request allowing it to be different from the global request

### DIFF
--- a/src/Fields/Media.php
+++ b/src/Fields/Media.php
@@ -102,7 +102,7 @@ class Media extends Field
      */
     protected function fillAttributeFromRequest(NovaRequest $request, $requestAttribute, $model, $attribute)
     {
-        $attr = $request->__get('__media__', []);
+        $attr = $request['__media__'] ?? [];
         $data = $attr[$requestAttribute] ?? [];
 
         collect($data)

--- a/src/Fields/Media.php
+++ b/src/Fields/Media.php
@@ -102,13 +102,9 @@ class Media extends Field
      */
     protected function fillAttributeFromRequest(NovaRequest $request, $requestAttribute, $model, $attribute)
     {
-    	$attr = request('__media__', []);
-        $data = $attr[$requestAttribute] ?? [];
+        $data = $request->file("__media__.{$requestAttribute}", []);
 
         collect($data)
-            ->filter(function ($value) {
-                return $value instanceof UploadedFile;
-            })
             ->each(function ($media) use ($requestAttribute) {
                 Validator::make([$requestAttribute => $media], [
                     $requestAttribute => array_merge($this->defaultValidatorRules, (array)$this->singleMediaRules),

--- a/src/Fields/Media.php
+++ b/src/Fields/Media.php
@@ -102,9 +102,12 @@ class Media extends Field
      */
     protected function fillAttributeFromRequest(NovaRequest $request, $requestAttribute, $model, $attribute)
     {
-        $data = $request->file("__media__.{$requestAttribute}", []);
+        $data = $request->all("__media__.{$requestAttribute}");
 
         collect($data)
+            ->filter(function ($value) {
+                return $value instanceof UploadedFile;
+            })
             ->each(function ($media) use ($requestAttribute) {
                 Validator::make([$requestAttribute => $media], [
                     $requestAttribute => array_merge($this->defaultValidatorRules, (array)$this->singleMediaRules),

--- a/src/Fields/Media.php
+++ b/src/Fields/Media.php
@@ -102,7 +102,8 @@ class Media extends Field
      */
     protected function fillAttributeFromRequest(NovaRequest $request, $requestAttribute, $model, $attribute)
     {
-        $data = $request->all("__media__.{$requestAttribute}");
+        $attr = $request->__get('__media__', []);
+        $data = $attr[$requestAttribute] ?? [];
 
         collect($data)
             ->filter(function ($value) {


### PR DESCRIPTION
I have been working on a flexible content plugin for Nova whereby I manipulated the global request and passed the modified request down to the nested resources.

Due to the plugin accessing the global request my files where never found.

Edit: Thanks so much for your work on this, saved me a TON of time on an already time sensitive project. 🙌