### PR TITLE
Use all of the request data during validation

### DIFF
--- a/src/Fields/Media.php
+++ b/src/Fields/Media.php
@@ -122,13 +122,21 @@ class Media extends Field
             ->filter(function ($value) {
                 return $value instanceof UploadedFile;
             })
-            ->each(function ($media) use ($requestAttribute) {
-                Validator::make([$requestAttribute => $media], [
+            ->each(function ($media) use ($request, $requestAttribute) {
+                $requestToValidateSingleMedia = array_merge($request->toArray(), [
+                    $requestAttribute => $media,
+                ]);
+
+                Validator::make($requestToValidateSingleMedia, [
                     $requestAttribute => array_merge($this->defaultValidatorRules, (array)$this->singleMediaRules),
                 ])->validate();
             });
 
-        Validator::make([$requestAttribute => $data], [$requestAttribute => $this->collectionMediaRules])
+        $requestToValidateCollectionMedia = array_merge($request->toArray(), [
+            $requestAttribute => $data,
+        ]);
+
+        Validator::make($requestToValidateCollectionMedia, [$requestAttribute => $this->collectionMediaRules])
             ->validate();
 
         return function () use ($request, $data, $attribute, $model) {


### PR DESCRIPTION
Convert request to array and merge with single and collection rules.
Validation rules affected: `required_if`, `required_unless`, `required_with`, `required_with_all`, `required_without`, `required_without_all`

With this PR the following case will be covered (*allows to save draft without cover*):
```php
public function fields(Request $request)
{
    return [
        Boolean::make('Active'),
        Images::make('Cover', 'cover')
            ->rules('required_if:active,1'),
    ];
}
```