### PR TITLE
Allow the package to work with the previous version of spatie media-lib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "php": ">=7.1.0",
         "laravel/framework": "^5.6|^6.0|^7.0",
         "laravel/nova": "^2.0|^3.0",
-        "spatie/laravel-medialibrary": "^8.0"
+        "spatie/laravel-medialibrary": "^7.5|^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Hello, 

Is there any reason why we need to enforce the use of saptie-media-library v8?

I mean, can we just make this compatible with v7 and v8 as well?

I ask this because v8 requires php 7.4.

People that has php7.3 will have to make changes.

