### PR TITLE
add custom properties functionality

### DIFF
--- a/src/Fields/HandlesCustomPropertiesTrait.php
+++ b/src/Fields/HandlesCustomPropertiesTrait.php
@@ -15,6 +15,7 @@ trait HandlesCustomPropertiesTrait
 {
     protected $customPropertiesFields = [];
     protected $customProperties = [];
+    protected $setCustomPropertiesCallback;
 
     public function customPropertiesFields(array $customPropertiesFields): self
     {
@@ -70,5 +71,19 @@ trait HandlesCustomPropertiesTrait
         }
 
         $media->save();
+    }
+
+    /**
+     * Set a custom properties callable callback
+     *
+     * @param callable $callback
+     *
+     * @return $this
+     */
+    public function setCustomProperties($callback)
+    {
+        $this->setCustomPropertiesCallback = $callback;
+
+        return $this;
     }
 }

--- a/src/Fields/Media.php
+++ b/src/Fields/Media.php
@@ -169,6 +169,12 @@ class Media extends Field
             ->filter(function ($value) {
                 return $value instanceof UploadedFile;
             })->map(function (UploadedFile $file, int $index) use ($request, $model, $collection) {
+
+                if (is_callable($this->setCustomPropertiesCallback)) {
+                    $this->customProperties = call_user_func($this->setCustomPropertiesCallback,
+                        $request, $file, $model, $collection, $index);
+                }
+
                 $media = $model->addMedia($file)->withCustomProperties($this->customProperties);
 
                 if ($this->responsive) {


### PR DESCRIPTION
example of save file hash custom property with callback

```
Images::make('Field', 'collection')
    ->setCustomProperties(function (Request $request, UploadedFile $file) {
        return [
            'md5_file' => md5_file($file->getRealPath())
        ];
    }),
```