### PR TITLE
Add config options for default conversions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -53,6 +53,29 @@ public function registerMediaCollections()
 }
 ```
 
+### Configure default conversion to use by collection and view
+If you have published the config files in the [install step](#install), you should have the following option:
+```php
+    /**
+     * Set a default conversion to use by collection.
+     * Can be set for all view with a string or by view with an array.
+     * Possible array keys are: index, detail, form, preview and fallback.
+     * 
+     * i.e.
+     * ['image' => 'thumb']
+     * or
+     * ['image' => [
+     *  'detail' => 'full',
+     *  'fallback' => 'thumb',
+     * ]
+     */
+    'collections-default-conversions' => [],
+```
+**If you come from an older version, just add this option to your existing config file.**
+
+With this option, you can configure a generic default for all view of a collection or specific to each view.
+The 'fallback' is used when the specific view is not defined. 
+
 ## Generic file management
 
 ![Generic file management](https://raw.githubusercontent.com/ebess/advanced-nova-media-library/master/docs/file-management.png)

--- a/src/Fields/HandlesConversionsTrait.php
+++ b/src/Fields/HandlesConversionsTrait.php
@@ -38,24 +38,31 @@ trait HandlesConversionsTrait
         return '';
     }
 
+    private function setDefaultConversion(string $collection)
+    {
+        $defaults = [
+            'conversionOnIndexView'  => $this->getDefaultConversionForCollection($collection, 'index') ?? '',
+            'conversionOnDetailView' => $this->getDefaultConversionForCollection($collection, 'detail') ?? '',
+            'conversionOnForm'       => $this->getDefaultConversionForCollection($collection, 'form') ?? '',
+            'conversionOnPreview'    => $this->getDefaultConversionForCollection($collection, 'preview') ?? '',
+        ];
+        if(method_exists($this, 'withMeta')) {
+            $this->withMeta($defaults);
+        } else {
+            $this->meta = array_merge($this->meta ?? [], $defaults);
+        }
+    }
+
     public function getConversionUrls(\Spatie\MediaLibrary\MediaCollections\Models\Media $media): array
     {
-        $collection = $media->collection_name;
+        $this->setDefaultConversion($media->collection_name);
         return [
             // original needed several purposes like cropping
             '__original__' => $media->getFullUrl(),
-            'indexView' => $media->getFullUrl($this->meta['conversionOnIndexView'] ??
-                $this->getDefaultConversionForCollection($collection, 'index')
-            ),
-            'detailView' => $media->getFullUrl($this->meta['conversionOnDetailView'] ??
-                $this->getDefaultConversionForCollection($collection, 'detail')
-            ),
-            'form' => $media->getFullUrl($this->meta['conversionOnForm'] ??
-                $this->getDefaultConversionForCollection($collection, 'form')
-            ),
-            'preview' => $media->getFullUrl($this->meta['conversionOnPreview'] ??
-                $this->getDefaultConversionForCollection($collection, 'preview')
-            ),
+            'indexView' => $media->getFullUrl($this->meta['conversionOnIndexView'] ?? ''),
+            'detailView' => $media->getFullUrl($this->meta['conversionOnDetailView'] ?? ''),
+            'form' => $media->getFullUrl($this->meta['conversionOnForm']  ?? ''),
+            'preview' => $media->getFullUrl($this->meta['conversionOnPreview'] ?? ''),
         ];
     }
 }

--- a/src/Fields/HandlesConversionsTrait.php
+++ b/src/Fields/HandlesConversionsTrait.php
@@ -27,15 +27,35 @@ trait HandlesConversionsTrait
         return $this->withMeta(compact('conversionOnPreview'));
     }
 
+    public function getDefaultConversionForCollection(string $collection, $view = null)
+    {
+        $defaultConversions = config("nova-media-library.collections-default-conversions.$collection");
+        if (is_string($defaultConversions)){
+            return $defaultConversions;
+        } elseif (is_array($defaultConversions)){
+            return $defaultConversions[$view] ?? ($defaultConversions['fallback'] ?? '');
+        }
+        return '';
+    }
+
     public function getConversionUrls(\Spatie\MediaLibrary\MediaCollections\Models\Media $media): array
     {
+        $collection = $media->collection_name;
         return [
             // original needed several purposes like cropping
             '__original__' => $media->getFullUrl(),
-            'indexView' => $media->getFullUrl($this->meta['conversionOnIndexView'] ?? ''),
-            'detailView' => $media->getFullUrl($this->meta['conversionOnDetailView'] ?? ''),
-            'form' => $media->getFullUrl($this->meta['conversionOnForm'] ?? ''),
-            'preview' => $media->getFullUrl($this->meta['conversionOnPreview'] ?? ''),
+            'indexView' => $media->getFullUrl($this->meta['conversionOnIndexView'] ??
+                $this->getDefaultConversionForCollection($collection, 'index')
+            ),
+            'detailView' => $media->getFullUrl($this->meta['conversionOnDetailView'] ??
+                $this->getDefaultConversionForCollection($collection, 'detail')
+            ),
+            'form' => $media->getFullUrl($this->meta['conversionOnForm'] ??
+                $this->getDefaultConversionForCollection($collection, 'form')
+            ),
+            'preview' => $media->getFullUrl($this->meta['conversionOnPreview'] ??
+                $this->getDefaultConversionForCollection($collection, 'preview')
+            ),
         ];
     }
 }

--- a/src/config/nova-media-library.php
+++ b/src/config/nova-media-library.php
@@ -2,4 +2,19 @@
 
 return [
     'enable-existing-media' => false,
+
+    /**
+     * Set a default conversion to use by collection.
+     * Can be set for all view with a string or by view with an array.
+     * Possible array keys are: index, detail, form, preview and fallback.
+     *
+     * i.e.
+     * ['image' => 'thumb']
+     * or
+     * ['image' => [
+     *  'detail' => 'full',
+     *  'fallback' => 'thumb',
+     * ]
+     */
+    'collections-default-conversions' => [],
 ];


### PR DESCRIPTION
This give the option to configure the default conversion to use for each view.
Especially useful for the existing media gallery that use the index view of each media.
It permit the controller to get the right url even if your passing from the MediaResource instead of the Field