### PR TITLE
Support Temporary Urls

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -134,6 +134,8 @@ return [
 Images::make('Image')->enableExistingMedia(),
 ```
 
+**Note**: This feature does not support temporary URLs.
+
 ## Names of uploaded images
 
 The default filename of the new uploaded file is the original filename. You can change this with the help of the function `setFileName`, which takes a callback function as the only param. This callback function has three params: `$originalFilename` (the original filename like `Fotolia 4711.jpg`), `$extension` (file extension like `jpg`), `$model` (the current model). Here are just 2 examples of what you can do:
@@ -266,6 +268,21 @@ class YourModel extends Model implements HasMedia
     }
 }
 ```
+
+## Temporary Urls
+
+If you are using Amazon S3 to store your media, you will need to use the `temporary` function on your field to generate
+a temporary signed URL. This function expects a valid Carbon instance that will specify when the URL should expire.
+
+```
+Images::make('Image 1', 'img1')
+    ->temporary(now()->addMinutes(5))
+
+Files::make('Multiple files', 'multiple_files')
+    ->temporary(now()->addMinutes(10),
+```
+
+**Note**: This feature does not work with the existing media feature. 
 
 # Credits
 

--- a/src/Fields/HandlesConversionsTrait.php
+++ b/src/Fields/HandlesConversionsTrait.php
@@ -38,4 +38,16 @@ trait HandlesConversionsTrait
             'preview' => $media->getFullUrl($this->meta['conversionOnPreview'] ?? ''),
         ];
     }
+
+    public function getTemporaryConversionUrls(\Spatie\MediaLibrary\MediaCollections\Models\Media $media): array
+    {
+        return [
+            // original needed several purposes like cropping
+            '__original__' => $media->getTemporaryUrl($this->secureUntil),
+            'indexView' => $media->getTemporaryUrl($this->secureUntil, $this->meta['conversionOnIndexView'] ?? ''),
+            'detailView' => $media->getTemporaryUrl($this->secureUntil, $this->meta['conversionOnDetailView'] ?? ''),
+            'form' => $media->getTemporaryUrl($this->secureUntil, $this->meta['conversionOnForm'] ?? ''),
+            'preview' => $media->getTemporaryUrl($this->secureUntil, $this->meta['conversionOnPreview'] ?? ''),
+        ];
+    }
 }

--- a/src/Fields/Media.php
+++ b/src/Fields/Media.php
@@ -217,7 +217,7 @@ class Media extends Field
                     $media->withResponsiveImages();
                 }
 
-                if (!empty($this->customHeaders)) {
+                if (! empty($this->customHeaders)) {
                     $media->addCustomHeaders($this->customHeaders);
                 }
 
@@ -245,7 +245,7 @@ class Media extends Field
     private function removeDeletedMedia($data, Collection $medias): Collection
     {
         $remainingIds = collect($data)->filter(function ($value) {
-            return !$value instanceof UploadedFile;
+            return ! $value instanceof UploadedFile;
         })->map(function ($value) {
             return $value;
         });
@@ -307,7 +307,7 @@ class Media extends Field
                 ->first()
                 ->singleFile ?? false;
 
-        $this->withMeta(['multiple' => !$isSingle]);
+        $this->withMeta(['multiple' => ! $isSingle]);
     }
 
     public function serializeMedia(\Spatie\MediaLibrary\MediaCollections\Models\Media $media): array


### PR DESCRIPTION
## Overview

This pull request aims to add support for signed temporary URs.

## Why?

If you are using Amazon S3 with Laravel Media Library and don't want to make your S3 bucket public, then you have to use signed, temporary URLs to view/access/download the media:

![Screenshot 2020-10-05 at 10 38 31](https://user-images.githubusercontent.com/6062337/95064153-3c1aa500-06f7-11eb-88f5-6888881d42a1.png)

## How does this PR fix this issue?

Happily, Laravel Media Library offers the ability to use temporary urls instead of ordinary urls, so I've added a `temporary` function to the `Images` and `Files` fields:

```
Images::make('Image 1', 'img1')
    ->temporary(now()->addMinutes(5))

Files::make('Multiple files', 'multiple_files')
    ->temporary(now()->addMinutes(10),
```

## Potential Issues

This pull request will not add support for tempoary URLs for the "existing media" feature, because:

1. I don't use it so I'm not familiar with it
2. The expiration time would have to be set globally in the config.

That said, I'm happy to add something if you can think of a good solution.

## Readme

I've updated the readme to descrbe the way in which this feature should be used.

## Conclusion

I hope that others find this PR useful since there are two issues requesting this feature. Please let me know if you need me to change anything at all, including code style and documentation.

