### PR TITLE
support spatie/laravel-medialibrary v9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "php": ">=7.4",
         "laravel/framework": "^5.6|^6.0|^7.0|^8.0",
         "laravel/nova": "^2.0|^3.0",
-        "spatie/laravel-medialibrary": "^8.0"
+        "spatie/laravel-medialibrary": "^8.0|^9.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Add support for spatie/laravel-medialibrary v9

Solves: https://github.com/ebess/advanced-nova-media-library/issues/216