### PR TITLE
Correct import according to change from Spatie

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,7 @@ php artisan vendor:publish --tag=nova-media-library
 
 Let's assume you configured your model to use the media library like following:
 ```php
-use Spatie\MediaLibrary\Models\Media;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 public function registerMediaConversions(Media $media = null)
 {


### PR DESCRIPTION
The new version of Laravel Media Library from spatie changed the structure of namespaces, this change corrects the Media model import instructed in the readme file