### PR TITLE
import route facade instead of relying on alias to be registered

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use Ebess\AdvancedNovaMediaLibrary\Http\Controllers\DownloadMediaController;
 use Ebess\AdvancedNovaMediaLibrary\Http\Controllers\MediaController;
+use Illuminate\Support\Facades\Route;
 
 Route::get('/download/{media}', [DownloadMediaController::class, 'show']);
 


### PR DESCRIPTION
This will add an import statement for the route facade instead of relying on the alias to be registered.

This will have no negative impact on any current installations.