### PR TITLE
fix atob issues

### DIFF
--- a/resources/js/converter.js
+++ b/resources/js/converter.js
@@ -1,10 +1,9 @@
 export default (base64, mime, fileName) => {
   mime = mime || '';
 
-  base64 = base64.replace(`data:${mime};base64,`, '');
   const sliceSize = 1024;
 
-  const byteChars = window.atob(base64);
+  const byteChars = window.atob(base64.split(',')[1]);
   const byteArrays = [];
 
   for (let offset = 0, len = byteChars.length; offset < len; offset += sliceSize) {


### PR DESCRIPTION
base64.replace(`data:${mime};base64,`, '') was not a reliable way to get the base64 data. This becomes apparent when we used an S3 image with cross-origin=anonymous  

The suggestion is to replace the above with a much simpler by a more reliable solution that works across local and remote images

window.atob(base64.split(',')[1])

The above solution is actually documented in many examples in the wild.