### PR TITLE
Include custom headers in addExistingMedia

### DIFF
--- a/src/Fields/HandlesExistingMediaTrait.php
+++ b/src/Fields/HandlesExistingMediaTrait.php
@@ -41,6 +41,10 @@ trait HandlesExistingMediaTrait
                     $media->withResponsiveImages();
                 }
 
+                if (! empty($this->customHeaders)) {
+                    $media->addCustomHeaders($this->customHeaders);
+                }
+
                 $media = $media->toMediaCollection($collection);
 
                 // fill custom properties for recently created media


### PR DESCRIPTION
When selecting existing media I found that custom headers weren't copied to the new record, which is a problem if they're required. This is a small fix for that.