### PR TITLE
Use getKeyName to determine key to support UUID based Media models

### DIFF
--- a/src/Fields/Media.php
+++ b/src/Fields/Media.php
@@ -264,14 +264,17 @@ class Media extends Field
             && ! is_array($value);
         });
 
-        $medias->pluck('id')->diff($remainingIds)->each(function ($id) use ($medias) {
+        $mediaClass = config('media-library.media_model');
+        $key = app($mediaClass)->getKeyName();
+
+        $medias->pluck($key)->diff($remainingIds)->each(function ($id, $key) use ($medias) {
             /** @var Media $media */
-            if ($media = $medias->where('id', $id)->first()) {
+            if ($media = $medias->where($key, $id)->first()) {
                 $media->delete();
             }
         });
 
-        return $remainingIds->intersect($medias->pluck('id'));
+        return $remainingIds->intersect($medias->pluck($key));
     }
 
     /**


### PR DESCRIPTION
When overriding the default media-library Media model with a custom class that overrides `$primaryKey`, saving an entity in Nova without changing the image can trigger a `Call to a member function determineOrderColumnName() on null` in `./vendor/spatie/laravel-medialibrary/src/MediaCollections/Models/Concerns/IsSorted.php`. This is because in `./src/Fields/Media.php` the name of the primary key is assumed to be `id`. This pull request fixes that.