### PR TITLE
fix: Vapor upload issues

### DIFF
--- a/src/Fields/Media.php
+++ b/src/Fields/Media.php
@@ -384,15 +384,11 @@ class Media extends Field
      */
     private function makeMediaFromVaporUpload(array $file, HasMedia $model): FileAdder
     {
-        $url = Storage::createS3Driver([
-            'key' => env('AWS_ACCESS_KEY_ID'),
-            'secret' => env('AWS_SECRET_ACCESS_KEY'),
-            'region' => env('AWS_DEFAULT_REGION'),
-            'bucket' => env('AWS_BUCKET'),
-            'url' => env('AWS_URL'),
-            'endpoint' => env('AWS_ENDPOINT'),
-            'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', false),
-        ])->temporaryUrl($file['key'], Carbon::now()->addHour());
+        $disk = config('filesystems.default');
+
+        $disk = config('filesystems.disks.' . $disk . 'driver') === 's3' ? $disk : 's3';
+
+        $url = Storage::disk($disk)->temporaryUrl($file['key'], Carbon::now()->addHour());
 
         return $model->addMediaFromUrl($url)
             ->usingFilename($file['file_name']);

--- a/src/Fields/Media.php
+++ b/src/Fields/Media.php
@@ -225,13 +225,13 @@ class Media extends Field
                     $media = $model->addMedia($file)->withCustomProperties($this->customProperties);
 
                     $fileName = $file->getClientOriginalName();
-                    $fileExtention = $file->getClientOriginalExtension();
+                    $fileExtension = $file->getClientOriginalExtension();
 
                 } else {
                     $media = $this->makeMediaFromVaporUpload($file, $model);
 
                     $fileName = $file['file_name'];
-                    $fileExtention = pathinfo($file['file_name'], PATHINFO_EXTENSION);
+                    $fileExtension = pathinfo($file['file_name'], PATHINFO_EXTENSION);
                 }
 
                 if ($this->responsive) {
@@ -244,7 +244,7 @@ class Media extends Field
 
                 if (is_callable($this->setFileNameCallback)) {
                     $media->setFileName(
-                        call_user_func($this->setFileNameCallback, $fileName, $fileExtention, $model)
+                        call_user_func($this->setFileNameCallback, $fileName, $fileExtension, $model)
                     );
                 }
 


### PR DESCRIPTION
- fix using setFileNameCallback/setNameCallback with files uploaded through Vapor
- fix generating url for private files using temporaryUrl
- fix selecting the wrong bucket when we have different disk for media library
based on vapor [`SignedStorageUrlController`](https://github.com/laravel/vapor-core/blob/2.0/src/Http/Controllers/SignedStorageUrlController.php)

