### PR TITLE
Make cropping by default configurable

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -201,6 +201,15 @@ It is possible to enforce cropping on upload, for example to ensure the image ha
 Images::make('Gallery')->mustCrop();
 ```
 
+### Disabling cropping by default
+
+By default, the cropping feature is enabled. To disable it by default for all images set `default-croppable` in `config/nova-media-library.php` to `false`:
+```php
+return [
+    'default-croppable' => false,
+];
+```
+
 ## Custom properties
 
 ![Custom properties](https://raw.githubusercontent.com/ebess/advanced-nova-media-library/master/docs/custom-properties.gif)

--- a/src/Fields/Images.php
+++ b/src/Fields/Images.php
@@ -10,7 +10,7 @@ class Images extends Media
     {
         parent::__construct($name, $attribute, $resolveCallback);
 
-        $this->croppable();
+        $this->croppable(config('nova-media-library.default-croppable', true));
     }
 
     /**
@@ -25,7 +25,7 @@ class Images extends Media
         return $this;
     }
 
-    public function croppable(bool $croppable = true): self
+    public function croppable(bool $croppable): self
     {
         return $this->withMeta(compact('croppable'));
     }

--- a/src/config/nova-media-library.php
+++ b/src/config/nova-media-library.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'default-croppable' => true,
     'enable-existing-media' => false,
     'hide-media-collections' => [],
 ];


### PR DESCRIPTION
I was updating a project to the latest version and noticed that all images had crop functionality.
For this project, however, cropping is done in an automated way and not needed. Instead of disabling cropping on all images by hand it would, in this case, be more convenient to alter the default behaviour. This PR makes that default behaviour configurable.

Do you see this as a viable PR @ebess?