### PR TITLE
Save custom fields on model creation

### DIFF
--- a/src/Fields/Media.php
+++ b/src/Fields/Media.php
@@ -222,6 +222,12 @@ class Media extends Field
                 return $value instanceof UploadedFile || is_array($value);
             })->map(function ($file, int $index) use ($request, $model, $collection) {
                 if ($file instanceof UploadedFile) {
+                    foreach ($this->customPropertiesFields as $field) {
+                        $requestAttribute = "__media-custom-properties__.{$collection}.{$index}.{$field->attribute}";
+                        $properties[$field->attribute] = $request->input($requestAttribute);
+                        $this->customProperties($properties);
+                    }
+                    
                     $media = $model->addMedia($file)->withCustomProperties($this->customProperties);
 
                     $fileName = $file->getClientOriginalName();


### PR DESCRIPTION
Hi,

We have a use case where we would like to customize conversions based on custom attributes. To get this working the custom fields need to be saved when the model is created (since the conversions triggers as soon as the model is created).

Here is an example of what we are trying to achieve, but could be any image manipulation based on a custom field:

```php
Images::make('Slideshow', 'slideshow')
    ...
    ->customPropertiesFields([
        Select::make('Crop', 'crop')->options([
            Manipulations::CROP_LEFT => 'Left',
            Manipulations::CROP_CENTER => 'Center',
            Manipulations::CROP_RIGHT => 'Right',
        ])->default(Manipulations::CROP_CENTER),
    ])
    ...
```

```php
public function registerMediaConversions(Media $media = null): void
{
    $crop = $media->getCustomProperty('crop') ?? Manipulations::CROP_CENTER;

    ...

    $this->addMediaConversion('thumb-two-thirds')
            ->performOnCollections('thumb')
            ->withResponsiveImages()
            ->crop($crop, 580, 870);

    ...
 ```

This pull request fixes that problem, if we need to improve or change the code let us know!