### PR TITLE
Improve "upload new media" button sizing

### DIFF
--- a/resources/js/components/Gallery.vue
+++ b/resources/js/components/Gallery.vue
@@ -53,7 +53,7 @@
 
     <span v-else-if="!editable" class="mr-3">&mdash;</span>
 
-    <span v-if="editable" class="form-file block md:w-1/3">
+    <span v-if="editable" class="form-file block max-w-xs">
       <input
         :id="`__media__${field.attribute}`"
         :multiple="multiple"


### PR DESCRIPTION
Using md:w-1/3 causes the size of the button to vary greatly across different sizes.

Using max-w-xs (which is present in the Nova tailwind stylesheet) creates something more consistent.