### PR TITLE
#337 Fix uploads with nested resources and multiple panels

### DIFF
--- a/src/Fields/HandlesCustomPropertiesTrait.php
+++ b/src/Fields/HandlesCustomPropertiesTrait.php
@@ -3,10 +3,11 @@
 namespace Ebess\AdvancedNovaMediaLibrary\Fields;
 
 use Laravel\Nova\Fields\Field;
-use Spatie\MediaLibrary\HasMedia;
 use Laravel\Nova\Http\Requests\NovaRequest;
-use Symfony\Component\HttpFoundation\FileBag;
+use Spatie\MediaLibrary\HasMedia;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\FileBag;
 
 /**
  * @mixin Media
@@ -30,10 +31,19 @@ trait HandlesCustomPropertiesTrait
         return $this;
     }
 
-    private function fillCustomPropertiesFromRequest(NovaRequest $request, HasMedia $model, string $collection)
+    /**
+     * @param  \Laravel\Nova\Http\Requests\NovaRequest  $request
+     * @param  string  $requestAttribute  The form attribute of the media field.
+     * @param  \Spatie\MediaLibrary\HasMedia  $model  The model which has associated media.
+     * @param  string  $collection  The selected media collection.
+     */
+    private function fillCustomPropertiesFromRequest(NovaRequest $request, string $requestAttribute, HasMedia $model, string $collection): void
     {
+        // If we are dealing with nested resources or multiple panels, media fields are prefixed.
+        $key = str_replace($collection, '__media__.'.$collection, $requestAttribute);
+
         $mediaItems = $model->getMedia($collection);
-        $items = $request->get('__media__', [])[$collection] ?? [];
+        $items = $request->input($key, []);
 
         // do not handle files as custom properties on files are not supported yet
         if ($items instanceof FileBag) {
@@ -44,27 +54,35 @@ trait HandlesCustomPropertiesTrait
             ->reject(function ($value) {
                 return $value instanceof UploadedFile || $value instanceof FileBag;
             })
-            ->each(function ($id, int $index) use ($request, $mediaItems, $collection) {
+            ->each(function ($id, int $index) use ($request, $mediaItems, $collection, $requestAttribute) {
                 if (! $media = $mediaItems->where('id', $id)->first()) {
                     return;
                 }
 
-                $this->fillMediaCustomPropertiesFromRequest($request, $media, $index, $collection);
+                $this->fillMediaCustomPropertiesFromRequest($request, $media, $index, $collection, $requestAttribute);
             });
     }
 
     /**
-     * @param \Spatie\MediaLibrary\Models\Media $media
+     * Fills custom properties for a given Media model from the request.
+     *
+     * @param  \Laravel\Nova\Http\Requests\NovaRequest  $request
+     * @param  \Spatie\MediaLibrary\MediaCollections\Models\Media  $media  The Media model with custom properties.
+     * @param  int  $index  The file's index in the corresponding Media collection, to retrieve its custom properties from the request.
+     * @param  string  $collection  The selected media collection.
+     * @param  string  $requestAttribute  The form attribute of the media field.
      */
-    private function fillMediaCustomPropertiesFromRequest(NovaRequest $request, $media, int $index, string $collection)
+    private function fillMediaCustomPropertiesFromRequest(NovaRequest $request, Media $media, int $index, string $collection, string $requestAttribute): void
     {
-        // prevent overriding the custom properties set by other processes like generating convesions
+        // prevent overriding the custom properties set by other processes like generating conversions
         $media->refresh();
 
         /** @var Field $field */
         foreach ($this->customPropertiesFields as $field) {
+            // If we are dealing with nested resources or multiple panels, custom property fields are prefixed.
+            $key = str_replace($collection, '__media-custom-properties__.'.$collection, $requestAttribute);
             $targetAttribute = "custom_properties->{$field->attribute}";
-            $requestAttribute = "__media-custom-properties__.{$collection}.{$index}.{$field->attribute}";
+            $requestAttribute = "{$key}.{$index}.{$field->attribute}";
 
             $field->fillInto($request, $media, $targetAttribute, $requestAttribute);
         }

--- a/src/Fields/Media.php
+++ b/src/Fields/Media.php
@@ -2,14 +2,14 @@
 
 namespace Ebess\AdvancedNovaMediaLibrary\Fields;
 
-use Illuminate\Support\Carbon;
-use Laravel\Nova\Fields\Field;
-use Spatie\MediaLibrary\HasMedia;
-use Illuminate\Support\Collection;
 use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Validator;
+use Laravel\Nova\Fields\Field;
 use Laravel\Nova\Http\Requests\NovaRequest;
+use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
 use Spatie\MediaLibrary\MediaCollections\FileAdder;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -283,7 +283,7 @@ class Media extends Field
     }
 
     /**
-     * @param HasMedia|HasMediaTrait $resource
+     * @param HasMedia|InteractsWithMedia $resource
      * @param null $attribute
      */
     public function resolve($resource, $attribute = null)
@@ -319,7 +319,7 @@ class Media extends Field
     }
 
     /**
-     * @param HasMedia|HasMediaTrait $resource
+     * @param HasMedia|InteractsWithMedia $resource
      */
     protected function checkCollectionIsMultiple(HasMedia $resource, string $collectionName)
     {

--- a/src/Fields/Media.php
+++ b/src/Fields/Media.php
@@ -190,11 +190,11 @@ class Media extends Field
         Validator::make($requestToValidateCollectionMedia, [$requestAttribute => $this->collectionMediaRules])
             ->validate();
 
-        return function () use ($request, $data, $attribute, $model) {
+        return function () use ($request, $data, $attribute, $model, $requestAttribute) {
             $this->handleMedia($request, $model, $attribute, $data);
 
             // fill custom properties for existing media
-            $this->fillCustomPropertiesFromRequest($request, $model, $attribute);
+            $this->fillCustomPropertiesFromRequest($request, $requestAttribute, $model, $attribute);
         };
     }
 

--- a/src/Fields/Media.php
+++ b/src/Fields/Media.php
@@ -162,8 +162,8 @@ class Media extends Field
      */
     protected function fillAttributeFromRequest(NovaRequest $request, $requestAttribute, $model, $attribute)
     {
-        $attr = $request['__media__'] ?? [];
-        $data = $attr[$requestAttribute] ?? [];
+        $key = str_replace($attribute, '__media__.'.$attribute, $requestAttribute);
+        $data = $request[$key] ?? [];
 
         if ($attribute === 'ComputedField') {
             $attribute = call_user_func($this->computedCallback, $model);


### PR DESCRIPTION
When a media upload is submitted from a parent resource form (e.g. media is associated on a user’s profile, but you want to edit the whole user from the user resource form), this ensures that the media upload is properly associated.

This PR implements the change suggested by @aqjw in #337.

I also tested that the upload still works when submitted directly from the resource form where the media collection is defined (i.e. from the user's profile resource edit form).