### PR TITLE
__media-custom-properties__. is duplicated

### DIFF
--- a/src/Fields/HandlesCustomPropertiesTrait.php
+++ b/src/Fields/HandlesCustomPropertiesTrait.php
@@ -80,7 +80,8 @@ trait HandlesCustomPropertiesTrait
         /** @var Field $field */
         foreach ($this->customPropertiesFields as $field) {
             // If we are dealing with nested resources or multiple panels, custom property fields are prefixed.
-            $key = str_replace($collection, '__media-custom-properties__.'.$collection, $requestAttribute);
+            $key = '__media-custom-properties__.' . $collection;
+
             $targetAttribute = "custom_properties->{$field->attribute}";
             $requestAttribute = "{$key}.{$index}.{$field->attribute}";
 


### PR DESCRIPTION
When changing custom properties of multiple images
There is a problem that the key is created as `__media-custom-properties__.__media-custom-properties__.gallery`