### PR TITLE
Check existence of computed value before display

### DIFF
--- a/resources/js/components/fields/IndexField.vue
+++ b/resources/js/components/fields/IndexField.vue
@@ -7,7 +7,8 @@
     <span v-if="field.multiple">
       {{ field.value.map(({ file_name }) => file_name).join(', ') }}
     </span>
-    <span v-else>{{ field.value[0].file_name }}</span>
+    <span v-else-if="value">{{ field.value[0].file_name }}</span>
+    <span v-else>&mdash;</span>
   </div>
 </template>
 


### PR DESCRIPTION
There is an issue which became present in Laravel Nova v4 when using single media collections. When a record does not have a media collection as defined in the Files field, it will result in the following frontend error:

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'file_name')
    at Proxy.<anonymous> (media-lib-images-field:2:43292)
    at renderComponentRoot (runtime-core.esm-bundler.js:816:1)
    at ReactiveEffect.componentUpdateFn [as fn] (runtime-core.esm-bundler.js:5701:1)
    at ReactiveEffect.run (reactivity.esm-bundler.js:178:1)
    at instance.update (runtime-core.esm-bundler.js:5814:1)
    at setupRenderEffect (runtime-core.esm-bundler.js:5822:1)
    at mountComponent (runtime-core.esm-bundler.js:5612:1)
    at processComponent (runtime-core.esm-bundler.js:5565:1)
    at patch (runtime-core.esm-bundler.js:5040:1)
    at mountChildren (runtime-core.esm-bundler.js:5284:1)
```

This is caused by the value attribute in the API response being an empty array. In Nova 4 the error will stop the table drawing process. In Nova 3 the same error is present but the table drawing just continues.