### PR TITLE
When trigger validation's error, nova show name instead of attr…

### DIFF
--- a/src/Fields/Media.php
+++ b/src/Fields/Media.php
@@ -181,7 +181,9 @@ class Media extends Field
 
                 Validator::make($requestToValidateSingleMedia, [
                     $requestAttribute => array_merge($this->defaultValidatorRules, (array)$this->singleMediaRules),
-                ])->validate();
+                ])
+                ->addCustomAttributes($this->getValidationAttributeNames($request))
+                ->validate();
             });
 
         $requestToValidateCollectionMedia = array_merge($request->toArray(), [
@@ -189,6 +191,7 @@ class Media extends Field
         ]);
 
         Validator::make($requestToValidateCollectionMedia, [$requestAttribute => $this->collectionMediaRules])
+            ->addCustomAttributes($this->getValidationAttributeNames($request))
             ->validate();
 
         return function () use ($request, $data, $attribute, $model, $requestAttribute) {


### PR DESCRIPTION
…ibute
```
Images::make('Main image', 'main')->rules('required'),
```
if user not upload to main attribute, nova would show error "The main field is required."

After adding this customAttributes to validator, nova would show error "The Main image field is required."