### PR TITLE
#423 - Add support for spatie/laravel-medialibrary 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=7.4",
         "laravel/framework": "^8.0|^9.0|^10.0",
         "laravel/nova": "^4.0",
-        "spatie/laravel-medialibrary": "^8.0|^9.0|^10.0"
+        "spatie/laravel-medialibrary": "^8.0|^9.0|^10.0|^11.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
It's already compatible with version 11. 
I did not find any use of the affected changes in the code, see [upgrade guide](https://github.com/spatie/laravel-medialibrary/blob/main/UPGRADING.md#from-v10-to-v11).

## From v10 to v11

- Image v3 is now used. Make sure to update your image conversions to the new syntax. See [the image docs](https://spatie.be/docs/image/v3) for more info.
- All event names have gained the `Event` suffix. For example `Spatie\MediaLibrary\MediaCollections\Events\MediaHasBeenAdded` is now `Spatie\MediaLibrary\MediaCollections\Events\MediaHasBeenAddedEvent`.
