### PR TITLE
Add `.gitattributes` to ignore files for composer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/docs               export-ignore
+/.editorconfig      export-ignore
+/docker-compose.yml export-ignore
+/yarn.lock          export-ignore


### PR DESCRIPTION
Add gitattributes file to prevent big files from being exported when installing package. Currently the `docs/` directory is included, which containers more than 5MB of images, unnecessarily.