### PR TITLE
Throw a 404 error if the file is not found

### DIFF
--- a/src/Http/Controllers/DownloadMediaController.php
+++ b/src/Http/Controllers/DownloadMediaController.php
@@ -9,7 +9,7 @@ class DownloadMediaController extends Controller
     public function show($mediaId)
     {
         $model = config('media-library.media_model') ?: Media;
-        $file = $model::find($mediaId);
+        $file = $model::findOrFail($mediaId);
 
         abort_unless($file->uuid === request()->get('uuid'), 403);
 


### PR DESCRIPTION
When a file is no longer available/existing, `$file `will be null hence, you will get a 

`Attempt to read property "uuid" on null` error when downloading the file

It should instead throw a 404 error