### PR TITLE
Add Laravel Nova authentication middleware to API routes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -117,7 +117,7 @@ public function fields(Request $request)
 If you upload the same media files to multiple models and you do not want to select it from the file system
 all over again, use this feature. Selecting an already existing media will **copy it**.
 
-**Attention**: This feature will expose an endpoint to every user of your application to search existing media. 
+**Attention**: This feature will expose an endpoint to every Nova authenticated user of your application to search existing media. 
 If your media upload / custom properties on the media models are confidential, **do not enable this feature!** 
 
 * Publish the config files if you did not yet

--- a/src/AdvancedNovaMediaLibraryServiceProvider.php
+++ b/src/AdvancedNovaMediaLibraryServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Route;
 use Laravel\Nova\Nova;
 use Laravel\Nova\Events\ServingNova;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Nova\Http\Middleware\Authenticate;
 
 class AdvancedNovaMediaLibraryServiceProvider extends ServiceProvider
 {
@@ -33,7 +34,7 @@ class AdvancedNovaMediaLibraryServiceProvider extends ServiceProvider
             return;
         }
 
-        Route::middleware(['nova'])
+        Route::middleware(['nova', Authenticate::class])
             ->prefix('nova-vendor/ebess/advanced-nova-media-library')
             ->group(__DIR__.'/../routes/api.php');
     }


### PR DESCRIPTION
Currently if you set the `enable-existing-media` config value to `true` the following endpoint is open for everyone without authentication:
`https://your-laravel-app.test/nova-vendor/ebess/advanced-nova-media-library/media`
This endpoint exposes all images in your application. Of course, this is a security vulnerability.

This happens because _sadly_ Laravel Nova does not protect API routes with the `Laravel\Nova\Http\Middleware\Authenticate` middleware by default. Reference: https://github.com/laravel/nova-issues/discussions/5496

This PR adds the Nova authenticate middleware so the API routes are only accessible by Nova authenticated users.