### PR TITLE
Revert "update to be compatible with nova 5"

### DIFF
--- a/src/Fields/Media.php
+++ b/src/Fields/Media.php
@@ -287,7 +287,7 @@ class Media extends Field
      * @param HasMedia|InteractsWithMedia $resource
      * @param null $attribute
      */
-    public function resolve($resource, ?string $attribute = null): void
+    public function resolve($resource, $attribute = null): void
     {
         $collectionName = $attribute ?? $this->attribute;
 


### PR DESCRIPTION
- Reverted the signature of the `resolve` method, so it works with Nova 4 again